### PR TITLE
go faster by caching writes per thread and merging as we go.

### DIFF
--- a/cpp/structs.hpp
+++ b/cpp/structs.hpp
@@ -2,9 +2,6 @@
 #include <vector>
 #include <unordered_set>
 #include <mutex>
-#include <shared_mutex>
-#include <atomic>
-#include <map>
 
 using namespace std;
 // #define DBG 1


### PR DESCRIPTION
changes hashy to keep a separate unordered set for each thread and occasionally merge them so it can go faster.
gets us pretty close to single threaded performance on while multi threaded.

before changes:
```
/pullrequests/nsch0e/cpp$ ./cubes 12 16
loading cache file "cubes_11.bin" (110990969 bytes) with N = 11
  num polycubes loading: 2522522
  loaded 2522522 cubes
N = 12 || generating new cubes from 2522522 base cubes.
converting to vector
sorting vector
starting 16 threads
  start from 0 to 157657
  start from 315315 to 472972
  start from 472972 to 630630
  start from 630630 to 788288
  start from 788288 to 945945
  start from 157657 to 315315
  start from 1103603 to 1261261
  start from 1891891 to 2049549
  start from 2049549 to 2207206
  start from 1418918 to 1576576
  start from 1261261 to 1418918
  start from 1576576 to 1734233
  start from 945945 to 1103603
  start from 1734233 to 1891891
  start from 2207206 to 2364864
  start from 2364864 to 2522522
  done from 157657 to 315315: found 18556407
  took 176.29 s
  done from 315315 to 472972: found 18557086
  took 176.46 s
  done from 0 to 157657: found 18562477
  took 176.98 s
  done from 945945 to 1103603: found 18575680
  took 179.51 s
  done from 1103603 to 1261261: found 18577250
  took 179.88 s
  done from 630630 to 788288: found 18578524
  took 180.18 s
  done from 1418918 to 1576576: found 18580358
  took 180.53 s
  done from 472972 to 630630: found 18581515
  took 180.78 s
  done from 788288 to 945945: found 18585166
  took 181.23 s
  done from 1261261 to 1418918: found 18589276
  took 181.88 s
  done from 1576576 to 1734233: found 18590585
  took 182.15 s
  done from 2049549 to 2207206: found 18591246
  took 182.42 s
  done from 1891891 to 2049549: found 18592482
  took 182.71 s
  done from 1734233 to 1891891: found 18592997
  took 182.80 s
  done from 2207206 to 2364864: found 18595011
  took 183.01 s
  done from 2364864 to 2522522: found 18598427
  took 183.26 s
  num cubes: 18598427
```
after
```
/pullrequests/bertie2/cpp$ ./cubes 12 16
loading cache file "cubes_11.bin" (110990969 bytes) with N = 11
  num polycubes loading: 2522522
  loaded 2522522 cubes
N = 12 || generating new cubes from 2522522 base cubes.
converting to vector
sorting vector
starting 16 threads
  start from 0 to 157657
  start from 157657 to 315315
  start from 315315 to 472972
  start from 472972 to 630630
  start from 1261261 to 1418918
  start from 1103603 to 1261261
  start from 945945 to 1103603
  start from 1576576 to 1734233
  start from 788288 to 945945
  start from 1418918 to 1576576
  start from 630630 to 788288
  start from 1734233 to 1891891
  start from 1891891 to 2049549
  start from 2049549 to 2207206
  start from 2207206 to 2364864
  start from 2364864 to 2522522
  done from 315315 to 472972: found 18551591
  took 54.29 s
  done from 157657 to 315315: found 18551757
  took 54.30 s
  done from 0 to 157657: found 18557105
  took 54.63 s
  done from 945945 to 1103603: found 18571278
  took 55.16 s
  done from 1103603 to 1261261: found 18573501
  took 55.38 s
  done from 630630 to 788288: found 18575023
  took 55.46 s
  done from 1418918 to 1576576: found 18578232
  took 55.63 s
  done from 472972 to 630630: found 18580322
  took 55.77 s
  done from 788288 to 945945: found 18587963
  took 56.04 s
  done from 1261261 to 1418918: found 18589049
  took 56.12 s
  done from 1576576 to 1734233: found 18589572
  took 56.16 s
  done from 2049549 to 2207206: found 18589579
  took 56.16 s
  done from 1891891 to 2049549: found 18592226
  took 56.38 s
  done from 1734233 to 1891891: found 18592238
  took 56.38 s
  done from 2207206 to 2364864: found 18593772
  took 56.54 s
  done from 2364864 to 2522522: found 18598378
  took 56.86 s
  num cubes: 18598427
```