### PR TITLE
evenly distribute subhashes to increase speed

### DIFF
--- a/cpp/Readme.md
+++ b/cpp/Readme.md
@@ -10,8 +10,11 @@
 ```
 
 ## environment variable:
-Cache can be disabled by setting USE_CACHE=0
+Cache reads can be disabled by setting USE_CACHE=0
+Cache writes ... WRITE_CACHE=0
 
 ```bash
 USE_CACHE=0 ./cubes N [NUM_THREADS]
+# and
+WRITE_CACHE=0 ./cubes N [NUM_THREADS]
 ```

--- a/cpp/cache.hpp
+++ b/cpp/cache.hpp
@@ -37,7 +37,7 @@ Hashy load(std::string path) {
             if (next.sparse[k].y > shape.y) shape.y = next.sparse[k].y;
             if (next.sparse[k].z > shape.z) shape.z = next.sparse[k].z;
         }
-        cubes.insert(next, shape);
+        cubes.insert(next);
     }
     printf("  loaded %lu cubes\n\r", cubes.size());
     return cubes;
@@ -47,7 +47,7 @@ void save(std::string path, Hashy &cubes, uint8_t n) {
     if (cubes.size() == 0) return;
     std::ofstream ofs(path, std::ios::binary);
     ofs << n;
-    for (const auto &s : cubes.byshape)
+    for (const auto &s : cubes.byhash)
         for (const auto &c : s.second.set) {
             for (const auto &p : c) {
                 ofs.write((const char *)&p.joined, sizeof(p.joined));

--- a/cpp/cache.hpp
+++ b/cpp/cache.hpp
@@ -26,7 +26,7 @@ Hashy load(std::string path) {
     }
     printf("  num polycubes loading: %d\n\r", numCubes);
     Hashy cubes;
-    cubes.init(cubelen);
+    cubes.init(1);
     for (int i = 0; i < numCubes; ++i) {
         Cube next;
         next.sparse.resize(cubelen);

--- a/cpp/cubes.cpp
+++ b/cpp/cubes.cpp
@@ -85,7 +85,6 @@ void expand(const Cube &c, Hashy &hashes) {
 void expandPart(std::vector<Cube> &base, Hashy &hashes, size_t start, size_t end) {
     printf("  start from %lu to %lu\n\r", start, end);
     auto t_start = std::chrono::steady_clock::now();
-
     for (auto i = start; i < end; ++i) {
         expand(base[i], hashes);
         auto count = i - start;
@@ -107,6 +106,7 @@ void expandPart(std::vector<Cube> &base, Hashy &hashes, size_t start, size_t end
 
 Hashy gen(int n, int threads = 1) {
     Hashy hashes;
+    hashes.init(n);
     if (n < 1)
         return {};
     else if (n == 1) {
@@ -127,7 +127,6 @@ Hashy gen(int n, int threads = 1) {
 
     auto base = gen(n - 1, threads);
     std::printf("N = %d || generating new cubes from %lu base cubes.\n\r", n, base.size());
-    hashes.init(n);
     int count = 0;
     if (threads == 1 || base.size() < 100) {
         auto start = std::chrono::steady_clock::now();

--- a/cpp/cubes.cpp
+++ b/cpp/cubes.cpp
@@ -120,9 +120,9 @@ Hashy gen(int n, int threads = 1) {
     }
 
     if (USE_CACHE) {
-        hashes = load("cubes_" + std::to_string(n) + ".bin");
-
-        if (hashes.size() != 0) return hashes;
+        if (hashes.size() != 0) {
+            return load("cubes_" + std::to_string(n) + ".bin");
+        }
     }
 
     auto base = gen(n - 1, threads);

--- a/cpp/cubes.cpp
+++ b/cpp/cubes.cpp
@@ -4,7 +4,6 @@
 #include <chrono>
 #include <iostream>
 #include <thread>
-#include <map>
 
 #include "cache.hpp"
 #include "results.hpp"

--- a/cpp/cubes.cpp
+++ b/cpp/cubes.cpp
@@ -4,6 +4,7 @@
 #include <chrono>
 #include <iostream>
 #include <thread>
+#include <map>
 
 #include "cache.hpp"
 #include "results.hpp"
@@ -70,7 +71,7 @@ void expand(const Cube &c, Hashy &hashes) {
                 lowestShape = res.first;
             }
         }
-        hashes.insert(std::move(lowestHashCube), lowestShape);
+        hashes.insert(std::move(lowestHashCube));
 #ifdef DBG
         std::printf("=====\n\r");
         // lowestHashCube.print();
@@ -110,11 +111,11 @@ Hashy gen(int n, int threads = 1) {
     if (n < 1)
         return {};
     else if (n == 1) {
-        hashes.insert(Cube{{XYZ{0, 0, 0}}}, XYZ{0, 0, 0});
+        hashes.insert(Cube{{XYZ{0, 0, 0}}});
         std::printf("%ld elements for %d\n\r", hashes.size(), n);
         return hashes;
     } else if (n == 2) {
-        hashes.insert(Cube{{XYZ{0, 0, 0}, XYZ{0, 0, 1}}}, XYZ{0, 0, 1});
+        hashes.insert(Cube{{XYZ{0, 0, 0}, XYZ{0, 0, 1}}});
         std::printf("%ld elements for %d\n\r", hashes.size(), n);
         return hashes;
     }
@@ -133,7 +134,8 @@ Hashy gen(int n, int threads = 1) {
         auto start = std::chrono::steady_clock::now();
         int total = base.size();
 
-        for (const auto &s : base.byshape) {
+        for (const auto &s : base.byhash)
+        {
             // printf("shapes %d %d %d\n\r", s.first.x, s.first.y, s.first.z);
             for (const auto &b : s.second.set) {
                 expand(b, hashes);
@@ -155,7 +157,7 @@ Hashy gen(int n, int threads = 1) {
     } else {
         std::vector<Cube> baseCubes;
         std::printf("converting to vector\n\r");
-        for (auto &s : base.byshape) {
+        for (auto &s : base.byhash) {
             baseCubes.insert(baseCubes.end(), s.second.set.begin(), s.second.set.end());
             s.second.set.clear();
             s.second.set.reserve(1);

--- a/cpp/cubes.cpp
+++ b/cpp/cubes.cpp
@@ -11,6 +11,7 @@
 #include "structs.hpp"
 
 bool USE_CACHE = 1;
+bool WRITE_CACHE = 1;
 
 void expand(const Cube &c, Hashy &hashes) {
     XYZSet candidates;
@@ -173,7 +174,7 @@ Hashy gen(int n, int threads = 1) {
         }
     }
     std::printf("  num cubes: %lu\n\r", hashes.size());
-    save("cubes_" + std::to_string(n) + ".bin", hashes, n);
+    if (WRITE_CACHE) save("cubes_" + std::to_string(n) + ".bin", hashes, n);
     if (sizeof(results) / sizeof(results[0]) > (n - 1) && n > 1) {
         if (results[n - 1] != hashes.size()) {
             std::printf("ERROR: result does not equal resultstable (%lu)!\n\r", results[n - 1]);
@@ -194,6 +195,7 @@ int main(int argc, char **argv) {
     if (argc > 2) threads = atoi(argv[2]);
 
     if (const char *p = getenv("USE_CACHE")) USE_CACHE = atoi(p);
+    if (const char *p = getenv("WRITE_CACHE")) WRITE_CACHE = atoi(p);
     gen(n, threads);
     return 0;
 }

--- a/cpp/structs.hpp
+++ b/cpp/structs.hpp
@@ -127,9 +127,6 @@ struct Hashy {
 
     template <typename CubeT>
     void insert(CubeT &&c) {
-        if(n_subhashes == 0){
-            n_subhashes = 1;
-        }
         auto &set = byhash[hash(c) % n_subhashes];
         set.insert(std::forward<CubeT>(c));
     }


### PR DESCRIPTION
I am fully on board with the meaningful multiple sets but the problem is cube shape is not evenly distributed so you end up hitting some sets exponentially harder than others, e.g for n=12 with you code:

```
17 buckets of size 0 
4 buckets of size 1 
1 buckets of size 11 
1 buckets of size 21 
1 buckets of size 69 
1 buckets of size 99 
1 buckets of size 103 
1 buckets of size 119 
1 buckets of size 158 
1 buckets of size 168 
1 buckets of size 193 
1 buckets of size 225 
1 buckets of size 313 
1 buckets of size 646 
1 buckets of size 800 
1 buckets of size 908 
1 buckets of size 1184 
1 buckets of size 1854 
1 buckets of size 2171 
1 buckets of size 2406 
1 buckets of size 2680 
1 buckets of size 2800 
1 buckets of size 2835 
1 buckets of size 3093 
1 buckets of size 4441 
1 buckets of size 4738 
1 buckets of size 6041 
1 buckets of size 7375 
1 buckets of size 8239 
1 buckets of size 9224 
1 buckets of size 10123 
1 buckets of size 10246 
1 buckets of size 10323 
1 buckets of size 11702 
1 buckets of size 13161 
1 buckets of size 16707 
1 buckets of size 21710 
1 buckets of size 22744 
1 buckets of size 40412 
1 buckets of size 61210 
1 buckets of size 69169 
1 buckets of size 84948 
1 buckets of size 88631 
1 buckets of size 94896 
1 buckets of size 115388 
1 buckets of size 124428 
1 buckets of size 160737 
1 buckets of size 178710 
1 buckets of size 203061 
1 buckets of size 357029 
1 buckets of size 421801 
1 buckets of size 448958 
1 buckets of size 467753 
1 buckets of size 508050 
1 buckets of size 544687 
1 buckets of size 786485 
1 buckets of size 799212 
1 buckets of size 819837 
1 buckets of size 989811 
1 buckets of size 1124222 
1 buckets of size 1444525 
1 buckets of size 1793893 
1 buckets of size 3113306 
1 buckets of size 3577634 
```

that's why your code slows down over time as certain hashes get busier and busier.

this commit spreads the writes evenly over a large block of sets to cause significantly less lock contention. resulting in 2^n evenly sized sets and almost 0 locking issues.