### PR TITLE
evenly distribute subhashes to increase speed

### DIFF
--- a/cpp/cache.hpp
+++ b/cpp/cache.hpp
@@ -26,8 +26,8 @@ Hashy load(std::string path) {
     }
     printf("  num polycubes loading: %d\n\r", numCubes);
     Hashy cubes;
-    cubes.init(cubelen);
-    for (size_t i = 0; i < numCubes; ++i) {
+    cubes.init(1);
+    for (uint i = 0; i < numCubes; ++i) {
         Cube next;
         next.sparse.resize(cubelen);
         XYZ shape;
@@ -37,7 +37,7 @@ Hashy load(std::string path) {
             if (next.sparse[k].y > shape.y) shape.y = next.sparse[k].y;
             if (next.sparse[k].z > shape.z) shape.z = next.sparse[k].z;
         }
-        cubes.insert(next, shape);
+        cubes.insert(next);
     }
     printf("  loaded %lu cubes\n\r", cubes.size());
     return cubes;
@@ -47,7 +47,7 @@ void save(std::string path, Hashy &cubes, uint8_t n) {
     if (cubes.size() == 0) return;
     std::ofstream ofs(path, std::ios::binary);
     ofs << n;
-    for (const auto &s : cubes.byshape)
+    for (const auto &s : cubes.byhash)
         for (const auto &c : s.second.set) {
             for (const auto &p : c) {
                 ofs.write((const char *)&p.joined, sizeof(p.joined));

--- a/cpp/structs.hpp
+++ b/cpp/structs.hpp
@@ -139,7 +139,7 @@ struct Hashy {
         // printf("insert into shape %d %d %d\n", shape.x, shape.y, shape.z);
         // c.print();
         if (byhash.find(hash) == byhash.end()) {
-            printf("ERROR! shape %d %d %d should already be in map!\n\r", shape.x, shape.y, shape.z);
+            printf("ERROR! hash %dshould already be in map!\n\r", hash);
             exit(-1);
         }
 #endif
@@ -155,7 +155,7 @@ struct Hashy {
         for (auto &set : byhash) {
             auto part = set.second.size();
 #ifdef DBG
-            std::printf("bucket [%2d %2d %2d]: %ld\n", set.first.x, set.first.y, set.first.z, part);
+            std::printf("bucket [%d]: %ld\n", hash, part);
 #endif
             sum += part;
         }


### PR DESCRIPTION
rebased my work onto latest code still runs faster, looking now at reworking to still possibly sort by shape
also includes a bugfix where load() assigned a empty Hashy onto hashes when caching was enabled but the file was not found, leading to undefined behavior