### PR TITLE
CMakeLists.txt refactor

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -1,15 +1,53 @@
-cmake_minimum_required(VERSION 3.0.2)
-project(cubes)
-
-set(CMAKE_BUILD_TYPE "Release")
-set(CMAKE_CXX_FLAGS "-std=c++17")
-set(CMAKE_CXX_FLAGS_RELEASE "-march=native -O3 -Wall -Wextra -Wno-unknown-pragmas")
-set(CMAKE_CXX_FLAGS_DEBUG "-march=native -O -Wall -Werror -Wextra -Wno-unknown-pragmas -D DEBUG")
+cmake_minimum_required(VERSION 3.14)
+project(cubes CXX)
 
 include_directories("include")
 include_directories("libraries")
-add_subdirectory("tests")
-file(GLOB SOURCES "src/*.cpp")
-add_executable(${PROJECT_NAME} ${SOURCES} "program.cpp")
+
+macro(ConfigureTarget Target)
+	# Enable C++17
+	target_compile_features(${Target} PUBLIC cxx_std_17)
+	target_compile_definitions(${Target} PUBLIC
+	# Debug defines:
+		$<$<CONFIG:Debug>:DEBUG>
+	# Release defines:
+		$<$<CONFIG:Release>:NDEBUG>
+		$<$<CONFIG:RelWithDebInfo>:NDEBUG>
+	)
+	target_compile_options(${Target} PUBLIC
+	# Flags used for all build types:
+		-Wall -Wextra
+	# Debug build flags:
+		$<$<CONFIG:Debug>:-O0>
+		$<$<CONFIG:Debug>:-Werror>
+		$<$<CONFIG:Debug>:-Wno-unknown-pragmas>
+	# Release build flags:
+		$<$<CONFIG:Release>:-O3>
+		$<$<CONFIG:Release>:-march=native>
+		$<$<CONFIG:Release>:-Wno-unknown-pragmas>
+	# Optimized with debug info (good for profiling the code)
+		$<$<CONFIG:RelWithDebInfo>:-march=native>
+		$<$<CONFIG:RelWithDebInfo>:-O3>
+		$<$<CONFIG:RelWithDebInfo>:-g>
+		$<$<CONFIG:RelWithDebInfo>:-fno-omit-frame-pointer>
+	)
+endmacro()
+
+# Source files
+add_library(CubeObjs OBJECT
+	"src/cubes.cpp"
+	"src/cache.cpp"
+	"src/rotations.cpp"
+)
+ConfigureTarget(CubeObjs)
+
+# Build main program
+add_executable(${PROJECT_NAME} "program.cpp" $<TARGET_OBJECTS:CubeObjs>)
 target_link_libraries(${PROJECT_NAME} pthread)
-target_compile_definitions(${PROJECT_NAME} PUBLIC NDEBUG)
+ConfigureTarget(${PROJECT_NAME})
+
+# Optionally build tests
+option(BUILD_TESTS OFF "Build test suite")
+if(BUILD_TESTS)
+	add_subdirectory(tests)
+endif()

--- a/cpp/tests/CMakeLists.txt
+++ b/cpp/tests/CMakeLists.txt
@@ -1,9 +1,5 @@
 cmake_minimum_required(VERSION 3.14)
-project(cubes_tests)
-
-set(CMAKE_BUILD_TYPE "Debug")
-set(CMAKE_CXX_FLAGS "-std=c++17")
-set(CMAKE_CXX_FLAGS_DEBUG "-march=native -O -Wall -Werror -Wextra -D DEBUG")
+project(cubes_tests CXX)
 
 # download google test
 include(FetchContent)
@@ -16,15 +12,11 @@ FetchContent_Declare(
 FetchContent_MakeAvailable(googletest)
 add_library(GTest::GTest INTERFACE IMPORTED)
 
-# include the source files
-include_directories("../include")
-file(GLOB SOURCES "../src/*.cpp")
-
 # include the test files
-include_directories("include")
 file(GLOB TESTS "src/*.cpp")
 
-add_executable(${PROJECT_NAME} ${SOURCES} ${TESTS})
+add_executable(${PROJECT_NAME} $<TARGET_OBJECTS:CubeObjs> ${TESTS})
+
 target_link_libraries(GTest::GTest INTERFACE gtest_main)
 target_link_libraries(${PROJECT_NAME} pthread GTest::GTest)
-target_compile_definitions(${PROJECT_NAME} PUBLIC)
+ConfigureTarget(${PROJECT_NAME})


### PR DESCRIPTION
- Make all target(s) configuration (defines, compile flags) consistent
- Use generator expressions for setting Debug/Release options
- Make Debug/Release/RelWithDebInfo work for all targets
- Optionally build tests: enabled with BUILD_TESTS option, defaults to OFF.

Compilation settings are now selected project-wise (cubes, cubes_tests) with CMAKE_BUILD_TYPE
and can be modified in `cpp/CMakeLists.txt` for Debug/Release/RelWithDebInfo targets.
If any target needs specific tuning this can be applied after `ConfigureTarget()` macro is used.