### PR TITLE
Optimize Rotations::rotate() more

### DIFF
--- a/cpp/include/cube.hpp
+++ b/cpp/include/cube.hpp
@@ -2,8 +2,8 @@
 #ifndef OPENCUBES_CUBE_HPP
 #define OPENCUBES_CUBE_HPP
 
-#include <stdint.h>
-
+#include <algorithm>
+#include <cstdint>
 #include <unordered_set>
 #include <vector>
 
@@ -50,6 +50,11 @@ struct Cube {
 
     void reserve(size_t N) { sparse.reserve(N); }
 
+    void empty_from(const Cube &c, int adjust = 0) {
+        sparse.clear();
+        sparse.reserve(c.size() + adjust);
+    }
+
     template <typename T>
     T &emplace_back(T &&p) {
         return sparse.emplace_back(std::forward<T>(p));
@@ -59,13 +64,12 @@ struct Cube {
 
     bool operator<(const Cube &b) const {
         if (size() != b.size()) return size() < b.size();
-        for (size_t i = 0; i < size(); ++i) {
-            if (sparse[i] < b.sparse[i])
-                return true;
-            else if (sparse[i] > b.sparse[i])
-                return false;
+        auto [aa, bb] = std::mismatch(begin(), end(), b.begin());
+        if (aa == end()) {
+            return false;
+        } else {
+            return *aa < *bb;
         }
-        return false;
     }
 
     void print() const {

--- a/cpp/include/hashes.hpp
+++ b/cpp/include/hashes.hpp
@@ -36,10 +36,9 @@ struct Hashy {
             set.emplace(std::forward<CubeT>(c));
         }
 
-        template <typename CubeT>
-        bool contains(CubeT &&c) {
+        bool contains(const Cube &c) {
             std::shared_lock lock(set_mutex);
-            return set.count(std::forward<CubeT>(c));
+            return set.count(c);
         }
 
         auto size() {
@@ -56,7 +55,7 @@ struct Hashy {
             HashCube hash;
             auto idx = hash(c) % NUM;
             auto &set = byhash[idx];
-            if (!set.contains(std::forward<CubeT>(c))) set.insert(std::forward<CubeT>(c));
+            if (!set.contains(c)) set.insert(std::forward<CubeT>(c));
             // printf("new size %ld\n\r", byshape[shape].size());
         }
 

--- a/cpp/include/rotations.hpp
+++ b/cpp/include/rotations.hpp
@@ -2,7 +2,6 @@
 #ifndef OPENCUBES_ROTATIONS_HPP
 #define OPENCUBES_ROTATIONS_HPP
 #include <array>
-#include <vector>
 
 #include "cube.hpp"
 
@@ -15,6 +14,6 @@ struct Rotations {
         {1, 2, 0, -1, 1, -1}, {1, 2, 0, 1, -1, -1},  {1, 2, 0, 1, 1, 1},   {2, 0, 1, -1, -1, 1},  {2, 0, 1, -1, 1, -1}, {2, 0, 1, 1, -1, -1},
         {2, 0, 1, 1, 1, 1},   {2, 1, 0, -1, -1, -1}, {2, 1, 0, -1, 1, 1},  {2, 1, 0, 1, -1, 1},   {2, 1, 0, 1, 1, -1},
     };
-    static std::pair<XYZ, std::vector<XYZ>> rotate(int i, XYZ shape, const Cube &orig);
+    static std::pair<XYZ, bool> rotate(int i, XYZ shape, const Cube &orig, Cube &dest);
 };
 #endif

--- a/cpp/src/rotations.cpp
+++ b/cpp/src/rotations.cpp
@@ -5,12 +5,11 @@
 
 #include "cube.hpp"
 
-std::pair<XYZ, std::vector<XYZ>> Rotations::rotate(int i, XYZ shape, const Cube &orig) {
+std::pair<XYZ, bool> Rotations::rotate(int i, XYZ shape, const Cube &orig, Cube &dest) {
     const auto L = LUT[i];
     XYZ out_shape{shape[L[0]], shape[L[1]], shape[L[2]]};
-    if (out_shape.x() > out_shape.y() || out_shape.y() > out_shape.z()) return {out_shape, {}};  // return here because violating shape
-    std::vector<XYZ> res;
-    res.reserve(orig.size());
+    if (out_shape.x() > out_shape.y() || out_shape.y() > out_shape.z()) return {out_shape, false};  // return here because violating shape
+    dest.empty_from(orig);
     for (const auto &o : orig) {
         XYZ next;
         if (L[3] < 0)
@@ -27,7 +26,7 @@ std::pair<XYZ, std::vector<XYZ>> Rotations::rotate(int i, XYZ shape, const Cube 
             next.z() = shape[L[2]] - o.data[L[2]];
         else
             next.z() = o.data[L[2]];
-        res.emplace_back(next);
+        dest.emplace_back(next);
     }
-    return {out_shape, res};
+    return {out_shape, true};
 }

--- a/cpp/tests/src/test_rotations.cpp
+++ b/cpp/tests/src/test_rotations.cpp
@@ -6,49 +6,50 @@ TEST(RotationsTests, TestRotateDoesNotThrow) {
     XYZ shape = XYZ(1, 1, 1);
     Cube cube = Cube{{XYZ(0, 0, 0)}};
     for (int i = 0; i < 24; i++) {
-        EXPECT_NO_THROW(Rotations::rotate(i, shape, cube));
+        Cube dest;
+        EXPECT_NO_THROW(Rotations::rotate(i, shape, cube, dest));
     }
 }
 
 TEST(RotationsTests, TestRotationsMatchesExpectation) {
     XYZ shape = XYZ(2, 1, 1);
     Cube cube = Cube{{XYZ(0, 0, 0), XYZ(1, 0, 0)}};
-    XYZ expected_shapes[24] = {
-        XYZ(2, 1, 1), XYZ(2, 1, 1), XYZ(2, 1, 1), XYZ(2, 1, 1), XYZ(2, 1, 1), XYZ(2, 1, 1), XYZ(2, 1, 1), XYZ(2, 1, 1), XYZ(1, 2, 1),
-        XYZ(1, 2, 1), XYZ(1, 2, 1), XYZ(1, 2, 1), XYZ(1, 1, 2), XYZ(1, 1, 2), XYZ(1, 1, 2), XYZ(1, 1, 2), XYZ(1, 2, 1), XYZ(1, 2, 1),
-        XYZ(1, 2, 1), XYZ(1, 2, 1), XYZ(1, 1, 2), XYZ(1, 1, 2), XYZ(1, 1, 2), XYZ(1, 1, 2)
+    XYZ expected_shapes[24] = {XYZ(2, 1, 1), XYZ(2, 1, 1), XYZ(2, 1, 1), XYZ(2, 1, 1), XYZ(2, 1, 1), XYZ(2, 1, 1), XYZ(2, 1, 1), XYZ(2, 1, 1),
+                               XYZ(1, 2, 1), XYZ(1, 2, 1), XYZ(1, 2, 1), XYZ(1, 2, 1), XYZ(1, 1, 2), XYZ(1, 1, 2), XYZ(1, 1, 2), XYZ(1, 1, 2),
+                               XYZ(1, 2, 1), XYZ(1, 2, 1), XYZ(1, 2, 1), XYZ(1, 2, 1), XYZ(1, 1, 2), XYZ(1, 1, 2), XYZ(1, 1, 2), XYZ(1, 1, 2)};
+    Cube expected_cubes[24] = {
+        {},
+        {},
+        {},
+        {},
+        {},
+        {},
+        {},
+        {},
+        {},
+        {},
+        {},
+        {},
+        {{XYZ(1, 1, 0), XYZ(1, 1, 1)}},
+        {{XYZ(1, 0, 2), XYZ(1, 0, 1)}},
+        {{XYZ(0, 1, 2), XYZ(0, 1, 1)}},
+        {{XYZ(0, 0, 0), XYZ(0, 0, 1)}},
+        {},
+        {},
+        {},
+        {},
+        {{XYZ(1, 1, 2), XYZ(1, 1, 1)}},
+        {{XYZ(1, 0, 0), XYZ(1, 0, 1)}},
+        {{XYZ(0, 1, 0), XYZ(0, 1, 1)}},
+        {{XYZ(0, 0, 2), XYZ(0, 0, 1)}},
     };
-    std::vector<XYZ> expected_cubes[24] = {
-        {},
-        {},
-        {},
-        {},
-        {},
-        {},
-        {},
-        {},
-        {},
-        {},
-        {},
-        {},
-        { XYZ(1, 1, 0),  XYZ(1, 1, 1), },
-        { XYZ(1, 0, 2),  XYZ(1, 0, 1), },
-        { XYZ(0, 1, 2),  XYZ(0, 1, 1), },
-        { XYZ(0, 0, 0),  XYZ(0, 0, 1), },
-        {},
-        {},
-        {},
-        {},
-        { XYZ(1, 1, 2),  XYZ(1, 1, 1), },
-        { XYZ(1, 0, 0),  XYZ(1, 0, 1), },
-        { XYZ(0, 1, 0),  XYZ(0, 1, 1), },
-        { XYZ(0, 0, 2),  XYZ(0, 0, 1), },
-    };
+
     std::stringstream shapes;
     std::stringstream cubes;
     for (int i = 0; i < 24; i++) {
-        auto rotated = Rotations::rotate(i, shape, cube);
-        EXPECT_EQ(rotated.first, expected_shapes[i]);
-        EXPECT_EQ(rotated.second, expected_cubes[i]);
+        Cube rotated;
+        auto [res, ok] = Rotations::rotate(i, shape, cube, rotated);
+        EXPECT_EQ(res, expected_shapes[i]);
+        EXPECT_EQ(rotated, expected_cubes[i]);
     }
 }


### PR DESCRIPTION
Bunch of small optimizations I made:
- Hoist nearly all allocations out from the hot loop of checking the rotations.
- Add out argument as `Rotations::rotate(...,Cube&)` and make it return `std::pair<XYZ,bool>` the second==true if rotation is valid. This avoids allocating memory every time in rotate().
- Update/Fix test_rotations.cpp to work with changed rotate()
- Cube::empty_from() added to clear cube and reserve enough space.
- clang-format the sources
- Misc fixups to the cubes code. 

this:
N = 12 || generating new cubes from 2522522 base cubes. 66 sets by shape for N=12
converting to vector
starting 2 threads
  done took 98.79 s [      0, 1261261]
  done took 114.17 s [1261261, 2522522]
  num cubes: 18598427
./build/cubes -n 12 -t 2  245.05s user 1.88s system 180% cpu 2:16.76 total
versus:
N = 12 || generating new cubes from 2522522 base cubes.
66 sets by shape for N=12
converting to vector
starting 2 threads
  done took 119.84 s [      0, 1261261]
  done took 139.10 s [1261261, 2522522]
  num cubes: 18598427
./build/cubes -n 12 -t 2  297.87s user 2.04s system 180% cpu 2:46.07 total


N=12 is biggest that I can test and most of time is still spent sorting the Cube rotations...
The Cube::empty_from() might temporal thing, since I have plans to make the Cube constant sized at point of construction.
There is no real need for dynamically growing vector as the Cube size is known.

Objections?