### PR TITLE
Feature/use split cache

### DIFF
--- a/cpp/include/cubes.hpp
+++ b/cpp/include/cubes.hpp
@@ -5,5 +5,5 @@
 #include "hashes.hpp"
 #include "newCache.hpp"
 
-FlatCache gen(int n, int threads = 1, bool use_cache = false, bool write_cache = false, bool split_cache = false);
+FlatCache gen(int n, int threads = 1, bool use_cache = false, bool write_cache = false, bool split_cache = false, bool use_split_cache = false);
 #endif

--- a/cpp/include/hashes.hpp
+++ b/cpp/include/hashes.hpp
@@ -70,15 +70,22 @@ struct Hashy {
     };
 
     std::map<XYZ, Subhashy<32>> byshape;
-    void init(int n) {
-        // create all subhashy which will be needed for N
+
+    static std::vector<XYZ> generateShapes(int n) {
+        std::vector<XYZ> out;
         for (int x = 0; x < n; ++x)
             for (int y = x; y < (n - x); ++y)
                 for (int z = y; z < (n - x - y); ++z) {
                     if ((x + 1) * (y + 1) * (z + 1) < n)  // not enough space for n cubes
                         continue;
-                    byshape[XYZ(x, y, z)].size();
+                    out.emplace_back(x, y, z);
                 }
+        return out;
+    }
+
+    void init(int n) {
+        // create all subhashy which will be needed for N
+        for (auto s : generateShapes(n)) byshape[s].size();
         std::printf("%ld sets by shape for N=%d\n\r", byshape.size(), n);
     }
 

--- a/cpp/include/newCache.hpp
+++ b/cpp/include/newCache.hpp
@@ -92,6 +92,7 @@ class CacheReader : public ICache {
     void printHeader();
     int printShapes();
     int loadFile(const std::string path);
+    void unload();
 
     size_t size() override { return header->numPolycubes; };
     uint32_t numShapes() override { return header->numShapes; };

--- a/cpp/program.cpp
+++ b/cpp/program.cpp
@@ -9,12 +9,13 @@ void configure_arguments(cli::Parser& parser) {
     parser.set_optional<bool>("c", "use_cache", false, "whether to load cache files");
     parser.set_optional<bool>("w", "write_cache", false, "wheather to save cache files");
     parser.set_optional<bool>("s", "split_cache", false, "wheather to save in sparate cache files per output shape");
+    parser.set_optional<bool>("u", "use_split_cache", false, "use separate cachefile by input shape");
 }
 
 int main(int argc, char** argv) {
     cli::Parser parser(argc, argv);
     configure_arguments(parser);
     parser.run_and_exit_if_error();
-    gen(parser.get<int>("n"), parser.get<int>("t"), parser.get<bool>("c"), parser.get<bool>("w"), parser.get<bool>("s"));
+    gen(parser.get<int>("n"), parser.get<int>("t"), parser.get<bool>("c"), parser.get<bool>("w"), parser.get<bool>("s"), parser.get<bool>("u"));
     return 0;
 }

--- a/cpp/src/cubes.cpp
+++ b/cpp/src/cubes.cpp
@@ -191,19 +191,7 @@ FlatCache gen(int n, int threads, bool use_cache, bool write_cache, bool split_c
         XYZ targetShape = tup.first;
         std::printf("process output shape %3d/%d [%2d %2d %2d]\n\r", outShapeCount, totalOutputShapes, targetShape.x(), targetShape.y(), targetShape.z());
         for (uint32_t sid = 0; sid < prevShapes.size(); ++sid) {
-            if (use_split_cache) {
-                // load cache file only for this shape
-                cr = CacheReader();  // TODO: this is just to call destructor of old CacheReader!
-                std::string cachefile = "cubes_" + std::to_string(n - 1) + "_" + std::to_string(prevShapes[sid].x()) + "-" +
-                                        std::to_string(prevShapes[sid].y()) + "-" + std::to_string(prevShapes[sid].z()) + ".bin";
-                cr.loadFile(cachefile);
-            }
-            auto s = base->getCubesByShape(sid);
-            auto &shape = s.shape();
-            if (shape != prevShapes[sid]) {
-                std::printf("ERROR caches shape does not match expected shape!\n");
-                exit(-1);
-            }
+            auto &shape = prevShapes[sid];
             int diffx = targetShape.x() - shape.x();
             int diffy = targetShape.y() - shape.y();
             int diffz = targetShape.z() - shape.z();
@@ -218,7 +206,21 @@ FlatCache gen(int n, int threads, bool use_cache, bool write_cache, bool split_c
             if (diffy == 1)
                 if (shape.y() == shape.x()) diffx = 1;
 
-            std::printf("  shape %d %d %d: #%lu\n\r", shape.x(), shape.y(), shape.z(), s.size());
+            std::printf("  shape %d %d %d\n\r", shape.x(), shape.y(), shape.z());
+
+            if (use_split_cache) {
+                // load cache file only for this shape
+                cr = CacheReader();  // TODO: this is just to call destructor of old CacheReader!
+                std::string cachefile = "cubes_" + std::to_string(n - 1) + "_" + std::to_string(prevShapes[sid].x()) + "-" +
+                                        std::to_string(prevShapes[sid].y()) + "-" + std::to_string(prevShapes[sid].z()) + ".bin";
+                cr.loadFile(cachefile);
+                // cr.printHeader();
+            }
+            auto s = base->getCubesByShape(sid);
+            if (shape != s.shape()) {
+                std::printf("ERROR caches shape does not match expected shape!\n");
+                exit(-1);
+            }
             // std::printf("starting %d threads\n\r", threads);
             std::vector<std::thread> ts;
             Workset ws(s, hashes, targetShape, shape, XYZ(diffx, diffy, diffz), abssum);

--- a/cpp/src/cubes.cpp
+++ b/cpp/src/cubes.cpp
@@ -210,7 +210,6 @@ FlatCache gen(int n, int threads, bool use_cache, bool write_cache, bool split_c
 
             if (use_split_cache) {
                 // load cache file only for this shape
-                cr = CacheReader();  // TODO: this is just to call destructor of old CacheReader!
                 std::string cachefile = "cubes_" + std::to_string(n - 1) + "_" + std::to_string(prevShapes[sid].x()) + "-" +
                                         std::to_string(prevShapes[sid].y()) + "-" + std::to_string(prevShapes[sid].z()) + ".bin";
                 cr.loadFile(cachefile);

--- a/cpp/src/cubes.cpp
+++ b/cpp/src/cubes.cpp
@@ -153,7 +153,7 @@ struct Worker {
     }
 };
 
-FlatCache gen(int n, int threads, bool use_cache, bool write_cache, bool split_cache) {
+FlatCache gen(int n, int threads, bool use_cache, bool write_cache, bool split_cache, bool use_split_cache) {
     Hashy hashes;
     if (n < 1)
         return {};
@@ -167,15 +167,15 @@ FlatCache gen(int n, int threads, bool use_cache, bool write_cache, bool split_c
         return FlatCache(hashes, n);
     }
 
-    std::string cachefile = "cubes_" + std::to_string(n - 1) + ".bin";
     CacheReader cr;
-    if (use_cache) {
+    if (use_cache && !use_split_cache) {
+        std::string cachefile = "cubes_" + std::to_string(n - 1) + ".bin";
         cr.loadFile(cachefile);
         cr.printHeader();
     }
     FlatCache fc;
     ICache *base = &cr;
-    if (!cr) {
+    if (!cr && !use_split_cache) {
         fc = gen(n - 1, threads, use_cache, write_cache, false);
         base = &fc;
     }
@@ -185,13 +185,25 @@ FlatCache gen(int n, int threads, bool use_cache, bool write_cache, bool split_c
     auto start = std::chrono::steady_clock::now();
     uint32_t totalOutputShapes = hashes.byshape.size();
     uint32_t outShapeCount = 0;
+    auto prevShapes = Hashy::generateShapes(n - 1);
     for (auto &tup : hashes.byshape) {
         outShapeCount++;
         XYZ targetShape = tup.first;
         std::printf("process output shape %3d/%d [%2d %2d %2d]\n\r", outShapeCount, totalOutputShapes, targetShape.x(), targetShape.y(), targetShape.z());
-        for (uint32_t sid = 0; sid < base->numShapes(); ++sid) {
+        for (uint32_t sid = 0; sid < prevShapes.size(); ++sid) {
+            if (use_split_cache) {
+                // load cache file only for this shape
+                cr = CacheReader();  // TODO: this is just to call destructor of old CacheReader!
+                std::string cachefile = "cubes_" + std::to_string(n - 1) + "_" + std::to_string(prevShapes[sid].x()) + "-" +
+                                        std::to_string(prevShapes[sid].y()) + "-" + std::to_string(prevShapes[sid].z()) + ".bin";
+                cr.loadFile(cachefile);
+            }
             auto s = base->getCubesByShape(sid);
             auto &shape = s.shape();
+            if (shape != prevShapes[sid]) {
+                std::printf("ERROR caches shape does not match expected shape!\n");
+                exit(-1);
+            }
             int diffx = targetShape.x() - shape.x();
             int diffy = targetShape.y() - shape.y();
             int diffz = targetShape.z() - shape.z();

--- a/cpp/src/newCache.cpp
+++ b/cpp/src/newCache.cpp
@@ -30,6 +30,7 @@ int CacheReader::printShapes(void) {
 }
 
 int CacheReader::loadFile(const std::string path) {
+    unload();
     path_ = path;
     fileDescriptor_ = open(path.c_str(), O_RDONLY);
 
@@ -69,7 +70,7 @@ ShapeRange CacheReader::getCubesByShape(uint32_t i) {
     return ShapeRange(start, end, header->n, XYZ(shapes[i].dim0, shapes[i].dim1, shapes[i].dim2));
 }
 
-CacheReader::~CacheReader() {
+void CacheReader::unload() {
     // unmap file from memory
     if (fileLoaded_) {
         if (munmap(filePointer, fileSize_) == -1) {
@@ -82,3 +83,5 @@ CacheReader::~CacheReader() {
         fileLoaded_ = false;
     }
 }
+
+CacheReader::~CacheReader() { unload(); }


### PR DESCRIPTION
this enables usage of split cache files from N-1 for generation of N.

cubes gets a new flag `--use_split_cache` or `-u`.

example usage:
```bash
# generate split cache files for N=8 
./cubes -n 8 -t 20 -w -s 
# use those cache files for generating split cache files for N=9
./cubes -n 9 -t 20 -w -s -c -u
```